### PR TITLE
feat: index for query

### DIFF
--- a/src/main/java/com/ourfantasy/auction/auction/model/Auction.java
+++ b/src/main/java/com/ourfantasy/auction/auction/model/Auction.java
@@ -13,10 +13,16 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-@Entity
-@Table(name = "auction")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "auction",
+        indexes = {
+                @Index(name = "idx_auction_status_created_at", columnList = "status, created_at"),
+                @Index(name = "idx_auction_status_closing_at", columnList = "status, closing_at"),
+                @Index(name = "idx_auction_item_id", columnList = "item_id"),
+                @Index(name = "idx_auction_cosigner_id", columnList = "cosigner_id")
+        })
 public class Auction extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ourfantasy/auction/auction/repository/AuctionCustomRepositoryImpl.java
+++ b/src/main/java/com/ourfantasy/auction/auction/repository/AuctionCustomRepositoryImpl.java
@@ -31,7 +31,6 @@ public class AuctionCustomRepositoryImpl extends QuerydslRepositorySupport imple
         BooleanExpression conditions = auction.status.eq(AuctionStatus.ACTIVE);
 
         List<Auction> content = from(auction)
-                .distinct()
                 .leftJoin(auction.item, item).fetchJoin()
                 .leftJoin(auction.cosigner, user).fetchJoin()
                 .where(conditions)
@@ -58,7 +57,6 @@ public class AuctionCustomRepositoryImpl extends QuerydslRepositorySupport imple
                 .and(item.category.eq(itemCategory));
 
         List<Auction> content = from(auction)
-                .distinct()
                 .leftJoin(auction.item, item).fetchJoin()
                 .leftJoin(auction.cosigner, user).fetchJoin()
                 .where(conditions)

--- a/src/main/java/com/ourfantasy/auction/config/persistence/P6spyPrettySqlFormatter.java
+++ b/src/main/java/com/ourfantasy/auction/config/persistence/P6spyPrettySqlFormatter.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
 
 public class P6spyPrettySqlFormatter implements MessageFormattingStrategy {
 
-    private static final String NEW_LINE = System.getProperty("line.separator");
+    private static final String NEW_LINE = System.lineSeparator();
     private static final String REGEX_PREFIX = "\\(";
     private static final String REGEX_SUFFIX = ".+?\\)";
     private static final String SELECT_PATTERN = "^(select)\\s";

--- a/src/main/java/com/ourfantasy/auction/item/model/Item.java
+++ b/src/main/java/com/ourfantasy/auction/item/model/Item.java
@@ -12,7 +12,9 @@ import lombok.NoArgsConstructor;
 import java.util.Random;
 
 @Entity
-@Table(name = "item")
+@Table(name = "item", indexes = {
+        @Index(name = "idx_item_category", columnList = "category")
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Item extends BaseTimeEntity {

--- a/src/main/resources/application-persistence.yml
+++ b/src/main/resources/application-persistence.yml
@@ -41,7 +41,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
     open-in-view: false
 
 decorator:


### PR DESCRIPTION
### 배경
auction 테이블 레코드 125202 개, item 테이블 레코드 200247 개인 상황에서 findLatestOpenedAuctions, findNearestClosingAuctionsByCategory 메소드가 응답 속도 평균 10초 내외

### 해결
조건에 사용되는 컬럼을 키로 인덱싱
auction 테이블은 필터링 조건 status 를 첫번째로, 정렬조건인 createdAt, closingAt 을 두번째 키로 인덱스를 생성
이외에 fk 관련 인덱스 생성
Item 테이블은 Cateroty 인덱스 생성

### 쿼리
│ 시간: 2025-03-21 00:30:59.304
│ 소요시간: 14ms
│ 연결ID: 8
│ 쿼리: 


    select
        distinct a1_0.id,
        a1_0.closing_at,
        a1_0.cosigner_id,
        c1_0.id,
        c1_0.created_at,
        c1_0.email,
        c1_0.nickname,
        c1_0.status,
        c1_0.updated_at,
        a1_0.created_at,
        a1_0.highest_bid_price,
        a1_0.item_id,
        i1_0.id,
        i1_0.category,
        i1_0.created_at,
        i1_0.detail,
        i1_0.name,
        i1_0.owner_id,
        i1_0.updated_at,
        a1_0.minimum_bid_increment,
        a1_0.starting_price,
        a1_0.status,
        a1_0.updated_at 
    from
        auction a1_0 
    left join
        item i1_0 
            on i1_0.id=a1_0.item_id 
    left join
        `user` c1_0 
            on c1_0.id=a1_0.cosigner_id 
    where
        a1_0.status=ACTIVE 
        and i1_0.category=FURNITURE 
    order by
        a1_0.closing_at 
    limit
        400, 20